### PR TITLE
Updated CharInfo stuff, got rid of "deprecated" warnings 

### DIFF
--- a/BitmapFontImporter.cs
+++ b/BitmapFontImporter.cs
@@ -36,7 +36,6 @@ public static class BitmapFontImporter
 		
 		XmlNode info = xml.GetElementsByTagName ("info") [0];
         XmlNode common = xml.GetElementsByTagName("common")[0];
-        XmlNode kernings = xml.GetElementsByTagName("kernings")[0];
 		XmlNodeList chars = xml.GetElementsByTagName ("chars") [0].ChildNodes;
 		
 		float texW = texture.width;
@@ -51,8 +50,7 @@ public static class BitmapFontImporter
 				CharacterInfo charInfo = new CharacterInfo ();
 			
 				charInfo.index = (int)ToFloat (charNode, "id");
-				charInfo.width = (int)ToFloat (charNode, "xadvance");
-				charInfo.flipped = false;
+				charInfo.advance = (int)ToFloat (charNode, "xadvance");
 			
 				r = new Rect ();
 				r.x = ((float)ToFloat (charNode, "x")) / texW;
@@ -60,7 +58,10 @@ public static class BitmapFontImporter
 				r.width = ((float)ToFloat (charNode, "width")) / texW;
 				r.height = ((float)ToFloat (charNode, "height")) / texH;
 				r.y = 1f - r.y - r.height;
-				charInfo.uv = r;
+				charInfo.uvBottomLeft = new Vector2(r.xMin, r.yMin);
+				charInfo.uvBottomRight = new Vector2(r.xMax, r.yMin);
+				charInfo.uvTopLeft = new Vector2(r.xMin, r.yMax);
+				charInfo.uvTopRight = new Vector2(r.xMax, r.yMax);
 			
 			
 				r = new Rect ();
@@ -70,7 +71,10 @@ public static class BitmapFontImporter
 				r.height = (float)ToFloat (charNode, "height");
 				r.y = -r.y;
 				r.height = -r.height;
-				charInfo.vert = r;
+				charInfo.minX = (int)r.xMin;
+				charInfo.maxX = (int)r.xMax;
+				charInfo.minY = (int)r.yMax;
+				charInfo.maxY = (int)r.yMin;
 			
 				charInfos [i] = charInfo;
 			}


### PR DESCRIPTION
Script was not working properly for me on Unity 5.3, so got rid of all those warnings, and used the recommended methods instead => working well again.
